### PR TITLE
fix: findTypeDependencies to generate a valid hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,7 @@
 ## 0.0.6
 
 - Add missing salt field in EIP712Domain object
+
+## 0.0.7
+
+- Fix findTypeDependencies

--- a/lib/util/typed_data.dart
+++ b/lib/util/typed_data.dart
@@ -257,7 +257,6 @@ class TypedDataUtil {
       result +=
           "${type}(${types[type]!.map((field) => '${field.type} ${field.name}').join(',')})";
     });
-    print("result=$result");
     return result;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: eth_sig_util
 description: Ethereum signature utility porting from JS
-version: 0.0.6
+version: 0.0.7
 homepage: https://wakumo.vn
 repository: https://github.com/wakumo/eth-sig-util
 

--- a/test/sign_typed_data.dart
+++ b/test/sign_typed_data.dart
@@ -9,7 +9,7 @@ void main() {
   const privateKey = '4af1bceebf7f3634ec3cff8a2c38e51178d5d4ce585c52d6043e5e2cc3418bb0';
   const json =
   r'''{"types":{"EIP712Domain":[{"type":"string","name":"name"},{"type":"string","name":"version"},{"type":"uint256","name":"chainId"},{"type":"address","name":"verifyingContract"}],"Part":[{"name":"account","type":"address"},{"name":"value","type":"uint96"}],"Mint721":[{"name":"tokenId","type":"uint256"},{"name":"tokenURI","type":"string"},{"name":"creators","type":"Part[]"},{"name":"royalties","type":"Part[]"}]},"domain":{"name":"Mint721","version":"1","chainId":4,"verifyingContract":"0x2547760120aed692eb19d22a5d9ccfe0f7872fce"},"primaryType":"Mint721","message":{"@type":"ERC721","contract":"0x2547760120aed692eb19d22a5d9ccfe0f7872fce","tokenId":"1","uri":"ipfs://ipfs/hash","creators":[{"account":"0xc5eac3488524d577a1495492599e8013b1f91efa","value":10000}],"royalties":[],"tokenURI":"ipfs://ipfs/hash"}}''';
-  test('should sign data with custom type', () {
+  test('should sign data with custom type which has an array', () {
     final signature = EthSigUtil.signTypedData(privateKey: privateKey, jsonData: json, version: TypedDataVersion.V4);
     expect(signature,'0x2ce14898e255b8d1e5f296a293548607720951e507a5416a0515baef0420984f2e28df8824206db9dbab0e7f5b14eeb834d48ada4444e5f15e7bfd777d2069481c');
   });

--- a/test/sign_typed_data.dart
+++ b/test/sign_typed_data.dart
@@ -1,0 +1,16 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:eth_sig_util/eth_sig_util.dart';
+import 'package:eth_sig_util/model/typed_data.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const privateKey = '4af1bceebf7f3634ec3cff8a2c38e51178d5d4ce585c52d6043e5e2cc3418bb0';
+  const json =
+  r'''{"types":{"EIP712Domain":[{"type":"string","name":"name"},{"type":"string","name":"version"},{"type":"uint256","name":"chainId"},{"type":"address","name":"verifyingContract"}],"Part":[{"name":"account","type":"address"},{"name":"value","type":"uint96"}],"Mint721":[{"name":"tokenId","type":"uint256"},{"name":"tokenURI","type":"string"},{"name":"creators","type":"Part[]"},{"name":"royalties","type":"Part[]"}]},"domain":{"name":"Mint721","version":"1","chainId":4,"verifyingContract":"0x2547760120aed692eb19d22a5d9ccfe0f7872fce"},"primaryType":"Mint721","message":{"@type":"ERC721","contract":"0x2547760120aed692eb19d22a5d9ccfe0f7872fce","tokenId":"1","uri":"ipfs://ipfs/hash","creators":[{"account":"0xc5eac3488524d577a1495492599e8013b1f91efa","value":10000}],"royalties":[],"tokenURI":"ipfs://ipfs/hash"}}''';
+  test('should sign data with custom type', () {
+    final signature = EthSigUtil.signTypedData(privateKey: privateKey, jsonData: json, version: TypedDataVersion.V4);
+    expect(signature,'0x2ce14898e255b8d1e5f296a293548607720951e507a5416a0515baef0420984f2e28df8824206db9dbab0e7f5b14eeb834d48ada4444e5f15e7bfd777d2069481c');
+  });
+}


### PR DESCRIPTION
If a type is an array, it fails to find a proper type so it doesn't generate a valid hash. This leads to an invalid signature.
https://github.com/MetaMask/eth-sig-util/blob/main/src/sign-typed-data.ts#L307
I used the same regex from Metamask and now it finds a proper type as an array literal is stripped. In addition, findTypeDependencies returns a Set to get rid of duplicated types.