### PR TITLE
x9IntegerToBytes bugfix

### DIFF
--- a/lib/util/signature.dart
+++ b/lib/util/signature.dart
@@ -160,14 +160,7 @@ class SignatureUtil {
       if (qLength < bytes.length) {
         return bytes.sublist(bytes.length - qLength);
       } else if (qLength > bytes.length) {
-        final tmp = List<int>.filled(qLength, 0);
-
-        final offset = qLength - bytes.length;
-        for (var i = 0; i < bytes.length; i++) {
-          tmp[i + offset] = bytes[i];
-        }
-
-        return tmp;
+        return List<int>.filled(qLength - bytes.length, 0) + bytes;
       }
 
       return bytes;

--- a/lib/util/signature.dart
+++ b/lib/util/signature.dart
@@ -158,7 +158,7 @@ class SignatureUtil {
       final bytes = encodeBigInt(s);
 
       if (qLength < bytes.length) {
-        return bytes.sublist(0, bytes.length - qLength);
+        return bytes.sublist(bytes.length - qLength);
       } else if (qLength > bytes.length) {
         final tmp = List<int>.filled(qLength, 0);
 


### PR DESCRIPTION
Looking at the implementation in [X9IntegerConverter.java](https://github.com/bcgit/bc-java/blob/master/core/src/main/java/org/bouncycastle/asn1/x9/X9IntegerConverter.java#L45), the x9IntegerToBytes function appears to be incorrect.